### PR TITLE
Update JSON version in gemspec

### DIFF
--- a/tempoiq.gemspec
+++ b/tempoiq.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_development_dependency "test-unit", "~> 0"
-  s.add_runtime_dependency "json", ">= 0"
+  s.add_runtime_dependency "json", "~> 1"
   s.add_runtime_dependency "httpclient", "~> 2.4", ">= 2.4.0"
   s.add_runtime_dependency "httpclient_link_header", "~> 0"
 end

--- a/tempoiq.gemspec
+++ b/tempoiq.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_development_dependency "test-unit", "~> 0"
-  s.add_runtime_dependency "json", "~> 0"
+  s.add_runtime_dependency "json", ">= 0"
   s.add_runtime_dependency "httpclient", "~> 2.4", ">= 2.4.0"
   s.add_runtime_dependency "httpclient_link_header", "~> 0"
 end


### PR DESCRIPTION
Previous json version spec didn't do what I thought and wouldn't pull in the more recent version of the JSON gem. 