### PR TITLE
Handle empty bodies on writes

### DIFF
--- a/lib/tempoiq/client.rb
+++ b/lib/tempoiq/client.rb
@@ -264,7 +264,8 @@ module TempoIQ
 
       result = remoter.post("/v2/write", JSON.dump(bulk.to_hash))
       if result.code == HttpResult::OK || result.code == HttpResult::MULTI
-        json = JSON.parse(result.body)
+        body = result.body.empty? ? "{}" : result.body
+        json = JSON.parse(body)
         MultiStatus.new(json)
       else
         raise HttpException.new(result)


### PR DESCRIPTION
Same as before. Handle empty body on write and translate that to a `MultiStatus`.

Test output against our spreadsheet:

```
Writing to existing sensor / device MV43: #<TempoIQ::MultiStatus:0x007fdc72a19810 @status={"ruby_existing-37479"=>{"device_state"=>"existing", "success"=>true, "message"=>nil}}>
Writing to existing sensor / device MV30: #<TempoIQ::MultiStatus:0x007fdc74056da8 @status={}>
Writing to nonexisting sensor MV43: #<TempoIQ::MultiStatus:0x007fdc740c2508 @status={"ruby_nonexisting_sensor-20459"=>{"device_state"=>"modified", "success"=>true, "message"=>nil
}}>
Writing to nonexisting sensor MV30: #<TempoIQ::MultiStatus:0x007fdc7419ced8 @status={"ruby_nonexisting_sensor-66971"=>{"success"=>false, "message"=>"error writing to storage: FER
R_GENERAL_ERROR: Unknown error occurred."}}>
Writing to nonexisting device MV43: #<TempoIQ::MultiStatus:0x007fdc741a8df0 @status={"ruby_nonexisting_device"=>{"device_state"=>"existing", "success"=>true, "message"=>nil}}>
Writing to nonexisting device MV30: #<TempoIQ::HttpResult:0x007fdc741b6068 @code=400, @headers={"Server"=>"nginx/1.0.15", "Date"=>"Wed, 08 Apr 2015 21:22:43 GMT", "Content-Type"=
>"application/prs.tempoiq.error.v1+json", "Connection"=>"keep-alive", "Content-Length"=>"89"}, @body="{\"message\":\"Aborting write. Nonexistent device keys in request: ruby_none
xisting_device\"}">
Partial success 1 MV43: #<TempoIQ::MultiStatus:0x007fdc741c11e8 @status={"ruby_partial_success_1-37023"=>{"device_state"=>"existing", "success"=>true, "message"=>nil}, "ruby_part
ial_success_1-not-found"=>{"device_state"=>"existing", "success"=>true, "message"=>nil}}>
Partial success 1 MV30: #<TempoIQ::HttpResult:0x007fdc741ede78 @code=400, @headers={"Server"=>"nginx/1.0.15", "Date"=>"Wed, 08 Apr 2015 21:22:44 GMT", "Content-Type"=>"applicatio
n/prs.tempoiq.error.v1+json", "Connection"=>"keep-alive", "Content-Length"=>"98"}, @body="{\"message\":\"Aborting write. Nonexistent device keys in request: ruby_partial_success_
1-not-found\"}">
Partial success 2 MV43: #<TempoIQ::MultiStatus:0x007fdc7422d3e8 @status={"ruby_partial_success_2-15732"=>{"device_state"=>"existing", "success"=>true, "message"=>nil}, "ruby_part
ial_success_2-77282"=>{"device_state"=>"modified", "success"=>true, "message"=>nil}}>
Partial success 2 MV30: #<TempoIQ::MultiStatus:0x007fdc742725b0 @status={"ruby_partial_success_2-30751"=>{"success"=>true, "message"=>nil}, "ruby_partial_success_2-18735"=>{"succ
ess"=>false, "message"=>"error writing to storage: FERR_GENERAL_ERROR: Unknown error occurred."}}>
Invalid datapoint MV43: #<TempoIQ::HttpException: TempoIQ::HttpException>
Invalid datapoint MV30: #<TempoIQ::HttpException: TempoIQ::HttpException>
```